### PR TITLE
Replace NotInheritable Classes with Private New to Module for native Methods

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeMethods.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeMethods.vb
@@ -10,7 +10,7 @@ Imports System.Text
 Namespace Microsoft.VisualBasic.CompilerServices
 
     <ComVisible(False)>
-    Friend NotInheritable Class NativeMethods
+    Friend Module NativeMethods
 
         <PreserveSig()>
         Friend Declare Auto Function _
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
 #Disable Warning CA1838 ' Avoid 'StringBuilder' parameters for P/Invokes
         <DllImport("user32", CharSet:=CharSet.Auto, PreserveSig:=True, SetLastError:=True)>
-        Friend Shared Function GetWindowText(hWnd As IntPtr, <Out(), MarshalAs(UnmanagedType.LPTStr)> lpString As StringBuilder, nMaxCount As Integer) As Integer
+        Friend Function GetWindowText(hWnd As IntPtr, <Out(), MarshalAs(UnmanagedType.LPTStr)> lpString As StringBuilder, nMaxCount As Integer) As Integer
 #Enable Warning CA1838 ' Avoid 'StringBuilder' parameters for P/Invokes
         End Function
 
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
              PreserveSig:=True,
              BestFitMapping:=False,
              ThrowOnUnmappableChar:=True)>
-        Friend Shared Sub GetStartupInfo(<[In](), Out()> lpStartupInfo As NativeTypes.STARTUPINFO)
+        Friend Sub GetStartupInfo(<[In](), Out()> lpStartupInfo As NativeTypes.STARTUPINFO)
         End Sub
 
         <DllImport(
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
              PreserveSig:=True,
              BestFitMapping:=False,
              ThrowOnUnmappableChar:=True)>
-        Friend Shared Function CreateProcess(
+        Friend Function CreateProcess(
             lpApplicationName As String,
             lpCommandLine As String,
             lpProcessAttributes As NativeTypes.SECURITY_ATTRIBUTES,
@@ -133,15 +133,8 @@ Namespace Microsoft.VisualBasic.CompilerServices
         ''' <param name="lpBuffer">Pointer to a MEMORYSTATUSEX structure.</param>
         ''' <returns>True if the function succeeds. Otherwise, False.</returns>
         <DllImport("Kernel32.dll", CharSet:=CharSet.Auto, SetLastError:=True)>
-        Friend Shared Function GlobalMemoryStatusEx(ByRef lpBuffer As MEMORYSTATUSEX) As <MarshalAs(UnmanagedType.Bool)> Boolean
+        Friend Function GlobalMemoryStatusEx(ByRef lpBuffer As MEMORYSTATUSEX) As <MarshalAs(UnmanagedType.Bool)> Boolean
         End Function
 
-        ''' <summary>
-        ''' Adding a private constructor to prevent the compiler from generating a default constructor.
-        ''' </summary>
-        Private Sub New()
-        End Sub
-
-    End Class
-
+    End Module
 End Namespace

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/SafeNativeMethods.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/SafeNativeMethods.vb
@@ -7,8 +7,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
     <ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)>
     <ComVisible(False)>
-    Friend NotInheritable Class _
-        SafeNativeMethods
+    Friend Module SafeNativeMethods
 
         <PreserveSig()> Friend Declare Function _
             IsWindowEnabled _
@@ -22,12 +21,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
             GetWindowThreadProcessId _
                 Lib "user32" (hwnd As IntPtr, ByRef lpdwProcessId As Integer) As Integer
 
-        ''' <summary>
-        ''' Adding a private constructor to prevent the compiler from generating a default constructor.
-        ''' </summary>
-        Private Sub New()
-        End Sub
-    End Class
-
+    End Module
 End Namespace
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/UnsafeNativeMethods.vb
@@ -6,7 +6,7 @@ Imports System.Runtime.InteropServices
 Namespace Microsoft.VisualBasic.CompilerServices
 
     <ComVisible(False)>
-    Friend NotInheritable Class UnsafeNativeMethods
+    Friend Module UnsafeNativeMethods
 
         ''' <summary>
         ''' Gets the state of the specified key on the keyboard when the function
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         ''' if the key is toggled on (i.e. for keys like CapsLock)
         ''' </returns>
         <DllImport("User32.dll", ExactSpelling:=True, CharSet:=CharSet.Auto)>
-        Friend Shared Function GetKeyState(KeyCode As Integer) As Short
+        Friend Function GetKeyState(KeyCode As Integer) As Short
         End Function
 
         ''' <summary>
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
         ''' by LocalAlloc or LocalReAlloc.
         ''' </summary>
         <DllImport("kernel32", ExactSpelling:=True, SetLastError:=True)>
-        Friend Shared Function LocalFree(LocalHandle As IntPtr) As IntPtr
+        Friend Function LocalFree(LocalHandle As IntPtr) As IntPtr
         End Function
 
         ''' <summary>
@@ -38,13 +38,8 @@ Namespace Microsoft.VisualBasic.CompilerServices
         ''' <param name="TotalFreeSpace">The amount of free spave on the disk.</param>
         ''' <returns>True if function succeeds in getting info otherwise False</returns>
         <DllImport("Kernel32.dll", CharSet:=CharSet.Auto, BestFitMapping:=False, SetLastError:=True)>
-        Friend Shared Function GetDiskFreeSpaceEx(Directory As String, ByRef UserSpaceFree As Long, ByRef TotalUserSpace As Long, ByRef TotalFreeSpace As Long) As <MarshalAs(UnmanagedType.Bool)> Boolean
+        Friend Function GetDiskFreeSpaceEx(Directory As String, ByRef UserSpaceFree As Long, ByRef TotalUserSpace As Long, ByRef TotalFreeSpace As Long) As <MarshalAs(UnmanagedType.Bool)> Boolean
         End Function
 
-        ''' <summary>
-        ''' Adding a private constructor to prevent the compiler from generating a default constructor.
-        ''' </summary>
-        Private Sub New()
-        End Sub
-    End Class
+    End Module
 End Namespace


### PR DESCRIPTION
DRAFT DO NOT REVIEW - this is a simple PR to repleace NotInheritable classes with Private New() with a Module. Modules are used elsewhere in Winforms. This is just a trial to make sure nothing breaks.